### PR TITLE
Fix Proj project website url

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,9 +38,9 @@ brew install proj
 apt-get install libproj-dev
 ```
 
-Or download binaries at http://proj4.org/
+Or download binaries at https://proj.org/
 
-By default, the gem looks for the Proj4 library in the following paths: 
+By default, the gem looks for the Proj4 library in the following paths:
 
 ```
 /usr/local
@@ -59,27 +59,27 @@ installation prefix directory using the `--with-proj-dir` option.
 
 ## Development
 
-After checking out the repo, run `bin/setup` to install dependencies. Then, run `rake test` to run 
+After checking out the repo, run `bin/setup` to install dependencies. Then, run `rake test` to run
 the tests. You can also run `bin/console` for an interactive prompt that will allow you to experiment.
 
-To install this gem onto your local machine, run `bundle exec rake install`. To release a new version, 
-update the version number in `version.rb`, and then run `bundle exec rake release`, which will create 
-a git tag for the version, push git commits and tags, and push the `.gem` file to 
+To install this gem onto your local machine, run `bundle exec rake install`. To release a new version,
+update the version number in `version.rb`, and then run `bundle exec rake release`, which will create
+a git tag for the version, push git commits and tags, and push the `.gem` file to
 [rubygems.org](https://rubygems.org).
 
 ## Contributing
 
-Bug reports and pull requests are welcome on GitHub at https://github.com/rgeo/rgeo-proj4. 
-This project is intended to be a safe, welcoming space for collaboration, and contributors are 
+Bug reports and pull requests are welcome on GitHub at https://github.com/rgeo/rgeo-proj4.
+This project is intended to be a safe, welcoming space for collaboration, and contributors are
 expected to adhere to the [Contributor Covenant](http://contributor-covenant.org) code of conduct.
 
 ## License
 
-The gem is available as open source under the terms of the 
+The gem is available as open source under the terms of the
 [MIT License](https://opensource.org/licenses/MIT).
 
 ## Code of Conduct
 
-Everyone interacting in the `rgeo-proj4` project’s codebases, issue trackers, chat rooms and mailing 
-lists is expected to follow the 
+Everyone interacting in the `rgeo-proj4` project’s codebases, issue trackers, chat rooms and mailing
+lists is expected to follow the
 [code of conduct](https://github.com/rgeo/rgeo-proj4/blob/master/CODE_OF_CONDUCT.md).


### PR DESCRIPTION
Even though there is redirect setup from proj4.org to proj.org, it would be nice to mention the correct url. Other changes are because of trailing space removals.