### PR TITLE
Patch extension to accept deprecated API

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,5 +14,15 @@ matrix:
   include:
     - dist: focal
       rvm: 2.7
+    - dist: bionic
+      rvm: 2.7
+    - os: osx
+      rvm: 2.7
+      addons:
+        homebrew:
+          packages:
+            - proj
   allow_failures:
     - dist: focal
+    - dist: bionic
+    - os: osx

--- a/ext/proj4_c_impl/extconf.rb
+++ b/ext/proj4_c_impl/extconf.rb
@@ -45,9 +45,10 @@ else
 
   found_proj_ = false
   header_dirs_, lib_dirs_ = dir_config("proj", header_dirs_, lib_dirs_)
-  if have_header("proj_api.h")
+  dflag = "-DACCEPT_USE_OF_DEPRECATED_PROJ_API_H"
+  if have_header("proj_api.h", nil, dflag)
     $libs << " -lproj"
-    if have_func("pj_init_plus", "proj_api.h")
+    if have_func("pj_init_plus", "proj_api.h", dflag)
       found_proj_ = true
     else
       $libs.gsub!(" -lproj", "")

--- a/ext/proj4_c_impl/main.c
+++ b/ext/proj4_c_impl/main.c
@@ -1,9 +1,9 @@
 /*
   Main initializer for Proj4 wrapper
 */
-
 #ifdef HAVE_PROJ_API_H
 #ifdef HAVE_PJ_INIT_PLUS
+#define ACCEPT_USE_OF_DEPRECATED_PROJ_API_H
 #define RGEO_PROJ4_SUPPORTED
 #endif
 #endif


### PR DESCRIPTION
Included `ACCEPT_USE_OF_DEPRECATED_PROJ_API_H` macro in `extconf` operations and `main.c`. This is a short term solution to #4 until a full upgrade can be done.