### PR TITLE
Set WKT_TYPE from Proj Version

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -42,6 +42,57 @@ jobs:
           bundle install
       - name: Test
         run: bundle exec rake
+  BuildProj:
+    strategy:
+      fail-fast: false
+      matrix:
+        ruby:
+          - "3.0"
+        os:
+          - ubuntu
+        proj:
+          - "8.0.0"
+          - "7.2.1"
+          - "7.1.1"
+          - "7.0.1"
+          - "6.3.1"
+          - "6.2.1"
+    runs-on: ${{ matrix.os }}-latest
+    continue-on-error: ${{ matrix.ruby == 'head' }}
+    name: Proj-(${{ matrix.proj }})
+    steps:
+      - uses: actions/checkout@v2
+      - name: Download Dependencies
+        run: |
+          sudo add-apt-repository ppa:ubuntugis/ubuntugis-unstable
+          sudo apt-get install curl libcurl4-openssl-dev libssl-dev libgeos-dev
+      - uses: actions/cache@v2
+        id: proj-cache
+        with:
+          path: ./proj-${{ matrix.proj }}
+          key: proj-${{ matrix.proj }}
+      - name: Download and Compile Proj
+        if: steps.proj-cache.outputs.cache-hit != 'true'
+        run: |
+          wget -c https://download.osgeo.org/proj/proj-${{ matrix.proj }}.tar.gz -O - | tar -xz
+          cd proj-${{ matrix.proj }}
+          ./configure --enable-shared --enable-fast-install
+          sudo su -c "make -j 8"
+          cd ../
+      - name: Install Proj
+        run: |
+          cd proj-${{ matrix.proj }}
+          sudo su -c "make install"
+          cd ../
+      - uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: ${{ matrix.ruby }}
+          bundler-cache: false
+      - name: Bundle Install
+        run: |
+          bundle install
+      - name: Test
+        run: bundle exec rake
   RuboCop:
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -20,36 +20,6 @@ jobs:
         os:
           - ubuntu
           - macos
-    runs-on: ${{ matrix.os }}-latest
-    continue-on-error: ${{ matrix.ruby == 'head' || matrix.os == 'macos' }}
-    name: Ruby ${{ matrix.ruby }} (${{ matrix.os }})
-    steps:
-      - uses: actions/checkout@v2
-      - name: Install Packages (Linux)
-        if: matrix.os == 'ubuntu'
-        run: |
-          sudo add-apt-repository ppa:ubuntugis/ubuntugis-unstable
-          sudo apt-get install libgeos-dev libproj-dev proj-bin -y
-      - name: Install Packages (Mac)
-        if: matrix.os == 'macos'
-        run: brew install geos proj
-      - uses: ruby/setup-ruby@v1
-        with:
-          ruby-version: ${{ matrix.ruby }}
-          bundler-cache: false
-      - name: Bundle Install
-        run: |
-          bundle install
-      - name: Test
-        run: bundle exec rake
-  BuildProj:
-    strategy:
-      fail-fast: false
-      matrix:
-        ruby:
-          - "3.0"
-        os:
-          - ubuntu
         proj:
           - "8.0.0"
           - "7.2.1"
@@ -58,31 +28,35 @@ jobs:
           - "6.3.1"
           - "6.2.1"
     runs-on: ${{ matrix.os }}-latest
-    continue-on-error: ${{ matrix.ruby == 'head' }}
-    name: Proj-(${{ matrix.proj }})
+    continue-on-error: ${{ matrix.ruby == 'head' || matrix.os == 'macos' }}
+    name: Ruby ${{ matrix.ruby }}, Proj-${{ matrix.proj }} (${{ matrix.os }})
     steps:
       - uses: actions/checkout@v2
-      - name: Download Dependencies
+      - name: Install Packages (Linux)
+        if: matrix.os == 'ubuntu'
         run: |
           sudo add-apt-repository ppa:ubuntugis/ubuntugis-unstable
           sudo apt-get install curl libcurl4-openssl-dev libssl-dev libgeos-dev
+      - name: Install Packages (Mac)
+        if: matrix.os == 'macos'
+        run: brew install geos make
       - uses: actions/cache@v2
         id: proj-cache
         with:
           path: ./proj-${{ matrix.proj }}
-          key: proj-${{ matrix.proj }}
+          key: proj-${{ matrix.proj }}-os-${{ matrix.os }}
       - name: Download and Compile Proj
         if: steps.proj-cache.outputs.cache-hit != 'true'
         run: |
           wget -c https://download.osgeo.org/proj/proj-${{ matrix.proj }}.tar.gz -O - | tar -xz
           cd proj-${{ matrix.proj }}
           ./configure --enable-shared --enable-fast-install
-          sudo su -c "make -j 8"
+          make -j 8
           cd ../
       - name: Install Proj
         run: |
           cd proj-${{ matrix.proj }}
-          sudo su -c "make install"
+          sudo make install
           cd ../
       - uses: ruby/setup-ruby@v1
         with:

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -28,7 +28,6 @@ jobs:
           - "6.3.1"
           - "6.2.1"
     runs-on: ${{ matrix.os }}-latest
-    continue-on-error: ${{ matrix.ruby == 'head' || matrix.os == 'macos' }}
     name: Ruby ${{ matrix.ruby }}, Proj-${{ matrix.proj }} (${{ matrix.os }})
     steps:
       - uses: actions/checkout@v2

--- a/ext/proj4_c_impl/main.c
+++ b/ext/proj4_c_impl/main.c
@@ -39,6 +39,11 @@ RGEO_BEGIN_C
 
 #ifdef RGEO_PROJ4_SUPPORTED
 
+#if PROJ_VERSION_MAJOR == 6 && PROJ_VERSION_MINOR < 3
+#define WKT_TYPE PJ_WKT2_2018
+#else
+#define WKT_TYPE PJ_WKT2_2019
+#endif
 
 typedef struct {
   PJ *pj;
@@ -234,7 +239,7 @@ static VALUE method_proj4_wkt_str(VALUE self)
   pj = data->pj;
   if (pj) {
     const char *const options[] = {"MULTILINE=NO", NULL};
-    str = proj_as_wkt(PJ_DEFAULT_CTX, pj, PJ_WKT2_2019, options);
+    str = proj_as_wkt(PJ_DEFAULT_CTX, pj, WKT_TYPE, options);
     if(str){
       result = rb_str_new2(str);
     }


### PR DESCRIPTION
Version 3 uses `PJ_WKT2_2019` as the formatting type for WKT representations. This only available in 6.3+ and breaks at the build stage for 6.2 versions. This PR defines a macro `WKT_TYPE` which will use the newest available version. It also expands on the CI to test against multiple Proj versions. 