### PR TITLE
Fix #19 Introduce `CRSToCRS` class

### DIFF
--- a/ext/proj4_c_impl/main.c
+++ b/ext/proj4_c_impl/main.c
@@ -51,6 +51,10 @@ typedef struct {
   char uses_radians;
 } RGeo_Proj4Data;
 
+typedef struct {
+  PJ *crs_to_crs;
+} RGeo_CRSToCRSData;
+
 
 // Destroy function for proj data.
 static void rgeo_proj4_free(void *ptr)
@@ -62,6 +66,17 @@ static void rgeo_proj4_free(void *ptr)
   free(data);
 }
 
+// Destroy function for crs_to_crs data.
+static void rgeo_crs_to_crs_free(void *ptr)
+{
+  RGeo_CRSToCRSData *data = (RGeo_CRSToCRSData *)ptr;
+  if(data->crs_to_crs){
+    proj_destroy(data->crs_to_crs);
+  }
+  free(data);
+}
+
+
 static size_t rgeo_proj4_memsize(const void *ptr)
 {
   size_t size = 0;
@@ -70,6 +85,17 @@ static size_t rgeo_proj4_memsize(const void *ptr)
   size += sizeof(*data);
   if(data->pj){
     size += sizeof(data->pj);
+  }
+  return size;
+}
+
+static size_t rgeo_crs_to_crs_memsize(const void *ptr)
+{
+  size_t size = 0;
+  const RGeo_CRSToCRSData *data = (const RGeo_CRSToCRSData *)ptr;
+  size += sizeof(*data);
+  if(data->crs_to_crs){
+    size += sizeof(data->crs_to_crs);
   }
   return size;
 }
@@ -111,6 +137,12 @@ static const rb_data_type_t rgeo_proj4_data_type = {
     0, 0,
     RUBY_TYPED_FREE_IMMEDIATELY};
 
+static const rb_data_type_t rgeo_crs_to_crs_data_type = {
+    "RGeo::CoordSys::CRSToCRS",
+    {0, rgeo_crs_to_crs_free, rgeo_crs_to_crs_memsize},
+    0, 0,
+    RUBY_TYPED_FREE_IMMEDIATELY};
+
 static VALUE rgeo_proj4_data_alloc(VALUE self)
 {
   VALUE result;
@@ -123,6 +155,21 @@ static VALUE rgeo_proj4_data_alloc(VALUE self)
     data->original_str = Qnil;
     data->uses_radians = 0;
     result = TypedData_Wrap_Struct(self, &rgeo_proj4_data_type, data);
+  }
+  return result;
+}
+
+
+static VALUE rgeo_crs_to_crs_data_alloc(VALUE self)
+{
+  VALUE result;
+  RGeo_CRSToCRSData *data = ALLOC(RGeo_CRSToCRSData);
+
+  result = Qnil;
+
+  if(data){
+    data->crs_to_crs = NULL;
+    result = TypedData_Wrap_Struct(self, &rgeo_crs_to_crs_data_type, data);
   }
   return result;
 }
@@ -321,57 +368,6 @@ static VALUE cmethod_proj4_version(VALUE module)
   return rb_sprintf("%d.%d.%d", PROJ_VERSION_MAJOR, PROJ_VERSION_MINOR, PROJ_VERSION_PATCH);
 }
 
-
-static VALUE cmethod_proj4_transform(VALUE module, VALUE from, VALUE to, VALUE x, VALUE y, VALUE z)
-{
-  VALUE result;
-  RGeo_Proj4Data *from_data;
-  RGeo_Proj4Data *to_data;
-  PJ *from_pj;
-  PJ *to_pj;
-  PJ *crs_to_crs;
-  PJ *gis_pj;
-  double xval, yval, zval;
-  PJ_COORD input;
-  PJ_COORD output;
-
-  result = Qnil;
-  TypedData_Get_Struct(from, RGeo_Proj4Data, &rgeo_proj4_data_type, from_data);
-  TypedData_Get_Struct(to, RGeo_Proj4Data, &rgeo_proj4_data_type, to_data);
-  from_pj = from_data->pj;
-  to_pj = to_data->pj;
-  if (from_pj && to_pj) {
-    crs_to_crs = proj_create_crs_to_crs_from_pj(PJ_DEFAULT_CTX, from_pj, to_pj, 0, NULL);
-    if(crs_to_crs){
-      // necessary to use proj_normalize_for_visualization so that we
-      // do not have to worry about the order of coordinates in every
-      // coord system.
-      gis_pj = proj_normalize_for_visualization(PJ_DEFAULT_CTX, crs_to_crs);
-      if(gis_pj){
-        proj_destroy(crs_to_crs);
-        crs_to_crs = gis_pj;
-
-        xval = rb_num2dbl(x);
-        yval = rb_num2dbl(y);
-        zval = NIL_P(z) ? 0.0 : rb_num2dbl(z);
-
-        input = proj_coord(xval, yval, zval, HUGE_VAL);
-        output = proj_trans(crs_to_crs, PJ_FWD, input);
-
-        result = rb_ary_new2(NIL_P(z) ? 2 : 3);
-        rb_ary_push(result, DBL2NUM(output.xyz.x));
-        rb_ary_push(result, DBL2NUM(output.xyz.y));
-        if(!NIL_P(z)){
-          rb_ary_push(result, DBL2NUM(output.xyz.z));
-        }
-      }
-      proj_destroy(crs_to_crs);
-    }
-  }
-  return result;
-}
-
-
 static VALUE cmethod_proj4_create(VALUE klass, VALUE str, VALUE uses_radians)
 {
   VALUE result;
@@ -389,17 +385,82 @@ static VALUE cmethod_proj4_create(VALUE klass, VALUE str, VALUE uses_radians)
   return result;
 }
 
+static VALUE cmethod_crs_to_crs_create(VALUE klass, VALUE from, VALUE to)
+{
+  VALUE result;
+  RGeo_Proj4Data *from_data;
+  RGeo_Proj4Data *to_data;
+  result = Qnil;
+  PJ *from_pj;
+  PJ *to_pj;
+  PJ *gis_pj;
+  PJ *crs_to_crs;
+  RGeo_CRSToCRSData* data;
+
+  TypedData_Get_Struct(from, RGeo_Proj4Data, &rgeo_proj4_data_type, from_data);
+  TypedData_Get_Struct(to, RGeo_Proj4Data, &rgeo_proj4_data_type, to_data);
+  from_pj = from_data->pj;
+  to_pj = to_data->pj;
+  crs_to_crs = proj_create_crs_to_crs_from_pj(PJ_DEFAULT_CTX, from_pj, to_pj, 0, NULL);
+
+  // necessary to use proj_normalize_for_visualization so that we
+  // do not have to worry about the order of coordinates in every
+  // coord system
+  gis_pj = proj_normalize_for_visualization(PJ_DEFAULT_CTX, crs_to_crs);
+  if(gis_pj){
+    proj_destroy(crs_to_crs);
+    crs_to_crs = gis_pj;
+  }
+  data = ALLOC(RGeo_CRSToCRSData);
+  if (data){
+    data->crs_to_crs = crs_to_crs;
+    result = TypedData_Wrap_Struct(klass, &rgeo_crs_to_crs_data_type, data);
+  }
+  return result;
+}
+
+
+static VALUE method_crs_to_crs_transform(VALUE self, VALUE x, VALUE y, VALUE z)
+{
+  VALUE result;
+  RGeo_CRSToCRSData *crs_to_crs_data;
+  PJ *crs_to_crs_pj;
+  double xval, yval, zval;
+  PJ_COORD input;
+  PJ_COORD output;
+
+  result = Qnil;
+  TypedData_Get_Struct(self, RGeo_CRSToCRSData, &rgeo_crs_to_crs_data_type, crs_to_crs_data);
+  crs_to_crs_pj = crs_to_crs_data->crs_to_crs;
+  if(crs_to_crs_pj){
+    xval = rb_num2dbl(x);
+    yval = rb_num2dbl(y);
+    zval = NIL_P(z) ? 0.0 : rb_num2dbl(z);
+
+    input = proj_coord(xval, yval, zval, HUGE_VAL);
+    output = proj_trans(crs_to_crs_pj, PJ_FWD, input);
+
+    result = rb_ary_new2(NIL_P(z) ? 2 : 3);
+    rb_ary_push(result, DBL2NUM(output.xyz.x));
+    rb_ary_push(result, DBL2NUM(output.xyz.y));
+    if(!NIL_P(z)){
+      rb_ary_push(result, DBL2NUM(output.xyz.z));
+    }
+  }
+  return result;
+}
 
 static void rgeo_init_proj4()
 {
   VALUE rgeo_module;
   VALUE coordsys_module;
   VALUE proj4_class;
+  VALUE crs_to_crs_class;
 
   rgeo_module = rb_define_module("RGeo");
   coordsys_module = rb_define_module_under(rgeo_module, "CoordSys");
-  proj4_class = rb_define_class_under(coordsys_module, "Proj4", rb_cObject);
 
+  proj4_class = rb_define_class_under(coordsys_module, "Proj4", rb_cObject);
   rb_define_alloc_func(proj4_class, rgeo_proj4_data_alloc);
   rb_define_module_function(proj4_class, "_create", cmethod_proj4_create, 2);
   rb_define_method(proj4_class, "initialize_copy", method_proj4_initialize_copy, 1);
@@ -413,8 +474,13 @@ static void rgeo_init_proj4()
   rb_define_method(proj4_class, "_geocentric?", method_proj4_is_geocentric, 0);
   rb_define_method(proj4_class, "_radians?", method_proj4_uses_radians, 0);
   rb_define_method(proj4_class, "_get_geographic", method_proj4_get_geographic, 0);
-  rb_define_module_function(proj4_class, "_transform_coords", cmethod_proj4_transform, 5);
   rb_define_module_function(proj4_class, "_proj_version", cmethod_proj4_version, 0);
+
+
+  crs_to_crs_class = rb_define_class_under(coordsys_module, "CRSToCRS", rb_cObject);
+  rb_define_alloc_func(crs_to_crs_class, rgeo_crs_to_crs_data_alloc);
+  rb_define_module_function(crs_to_crs_class, "_create", cmethod_crs_to_crs_create, 2);
+  rb_define_method(crs_to_crs_class, "_transform_coords", method_crs_to_crs_transform, 3);
 }
 
 

--- a/lib/rgeo/coord_sys/crs_to_crs.rb
+++ b/lib/rgeo/coord_sys/crs_to_crs.rb
@@ -1,0 +1,45 @@
+# frozen_string_literal: true
+
+require "singleton"
+module RGeo
+  module CoordSys
+    # This is a Ruby wrapper around a proj crs_to_crs
+    # A crs_to_crs transformation object is a pipeline between two known coordinate reference systems.
+    # https://proj.org/development/reference/functions.html#c.proj_create_crs_to_crs
+    class CRSToCRS
+      # transform the coordinates from the initial CRS to the destination CRS
+      def transform_coords(x, y, z)
+        _transform_coords(x, y, z)
+      end
+
+      class << self
+        def create(from, to)
+          _create(from, to)
+        end
+      end
+    end
+
+    # Store of all the created CRSToCRS
+    class CRSStore
+      include Singleton
+      class << self
+        def get(from, to)
+          instance.get(from, to)
+        end
+      end
+
+      Key = Struct.new(:from, :to)
+
+      def initialize
+        @store = Hash.new { |h, k| h[k] = CRSToCRS.create(k.from, k.to) }
+        @semaphore = Mutex.new
+      end
+
+      def get(from, to)
+        @semaphore.synchronize do
+          @store[Key.new(from, to)]
+        end
+      end
+    end
+  end
+end

--- a/lib/rgeo/coord_sys/proj4.rb
+++ b/lib/rgeo/coord_sys/proj4.rb
@@ -221,14 +221,14 @@ module RGeo
         # Transforms the given coordinate (x, y, [z]) from one proj4
         # coordinate system to another. Returns an array with either two
         # or three elements.
-
         def transform_coords(from_proj_, to_proj_, x_, y_, z_ = nil)
           if from_proj_._radians? && from_proj_._geographic?
             x_ *= ImplHelper::Math::DEGREES_PER_RADIAN
             y_ *= ImplHelper::Math::DEGREES_PER_RADIAN
           end
 
-          result_ = _transform_coords(from_proj_, to_proj_, x_, y_, z_)
+          crs_to_crs = CRSStore.get(from_proj_, to_proj_)
+          result_ = crs_to_crs.transform_coords(x_, y_, z_)
           if result_ && to_proj_._radians? && to_proj_._geographic?
             result_[0] *= ImplHelper::Math::RADIANS_PER_DEGREE
             result_[1] *= ImplHelper::Math::RADIANS_PER_DEGREE
@@ -273,19 +273,8 @@ module RGeo
           from_has_m_ = from_factory_.property(:has_m_coordinate)
           to_has_z_ = to_factory_.property(:has_z_coordinate)
           to_has_m_ = to_factory_.property(:has_m_coordinate)
-          x_ = from_point_.x
-          y_ = from_point_.y
-          if from_proj_._radians? && from_proj_._geographic?
-            x_ *= ImplHelper::Math::DEGREES_PER_RADIAN
-            y_ *= ImplHelper::Math::DEGREES_PER_RADIAN
-          end
-          coords_ = _transform_coords(from_proj_, to_proj_, x_, y_, from_has_z_ ? from_point_.z : nil)
+          coords_ = transform_coords(from_proj_, to_proj_, from_point_.x, from_point_.y, from_has_z_ ? from_point_.z : nil)
           return unless coords_
-
-          if to_proj_._radians? && to_proj_._geographic?
-            coords_[0] *= ImplHelper::Math::RADIANS_PER_DEGREE
-            coords_[1] *= ImplHelper::Math::RADIANS_PER_DEGREE
-          end
           extras_ = []
           extras_ << coords_[2].to_f if to_has_z_
           if to_has_m_

--- a/lib/rgeo/proj4.rb
+++ b/lib/rgeo/proj4.rb
@@ -2,6 +2,7 @@
 
 require "rgeo"
 require "rgeo/proj4/version"
+require "rgeo/coord_sys/crs_to_crs"
 require "rgeo/coord_sys/proj4"
 require "rgeo/coord_sys/srs_database/proj4_data"
 require "rgeo/coord_sys/proj4_c_impl"

--- a/test/coord_sys/crs_to_crs_test.rb
+++ b/test/coord_sys/crs_to_crs_test.rb
@@ -1,0 +1,29 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+class TestCrsToCrs < Minitest::Test # :nodoc:
+  def from
+    RGeo::CoordSys::Proj4.create("+proj=lcc +lat_1=49 +lat_2=44 +lat_0=46.5 +lon_0=3 +x_0=700000 +y_0=6600000 +ellps=GRS80 +towgs84=0,0,0,0,0,0,0 +units=m +no_defs +type=crs")
+  end
+
+  def to
+    RGeo::CoordSys::Proj4.create("+proj=longlat +ellps=WGS84 +datum=WGS84 +no_defs +type=crs")
+  end
+
+  def test_transform_coords
+    crs_to_crs = RGeo::CoordSys::CRSToCRS.create(from, to)
+    a, b = crs_to_crs.transform_coords(733_345.6496818807, 6_750_247.713332973, nil)
+    assert_close_enough(a, 3.4458703379573348)
+    assert_close_enough(b, 47.85177684510492)
+  end
+
+  def test_store
+    crs_to_crs1 = RGeo::CoordSys::CRSStore.get(from, to)
+    crs_to_crs2 = RGeo::CoordSys::CRSStore.get(from, RGeo::CoordSys::Proj4.create("+proj=longlat +ellps=WGS84 +datum=WGS84 +no_defs +type=crs"))
+    crs_to_crs3 = RGeo::CoordSys::CRSStore.get(to, from)
+    assert(crs_to_crs1, "crs_to_crs must not be nil")
+    assert_equal(crs_to_crs1, crs_to_crs2)
+    refute_equal(crs_to_crs1, crs_to_crs3)
+  end
+end

--- a/test/coord_sys/proj4_test.rb
+++ b/test/coord_sys/proj4_test.rb
@@ -140,12 +140,6 @@ class TestProj4 < Minitest::Test # :nodoc:
     [x / 6_378_137.0, (2.0 * Math.atan(Math.exp(y / 6_378_137.0)) - Math::PI / 2.0)]
   end
 
-  def assert_close_enough(a, b)
-    delta = Math.sqrt(a * a + b * b) * 0.00000001
-    delta = 1e-7 if delta < 1e-7
-    assert_in_delta(a, b, delta)
-  end
-
   def assert_xy_close(xy1, xy2)
     assert_close_enough(xy1[0], xy2[0])
     assert_close_enough(xy1[1], xy2[1])

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -15,3 +15,8 @@ def psych_load(*args)
     Psych.load(*args)
   end
 end
+
+# assert that a and b float numbers are very close to each other
+def assert_close_enough(a, b)
+  assert_in_delta(a, b, 1e-7)
+end


### PR DESCRIPTION
In newer versions of proj, you need to create a crs_to_crs projection and then transform coordinates with that, whereas in older versions you would pass 2 separate CRS's into the transform function.



This PR:
- Create a new class `RGeo::CoordSys::CRSToCRS` that is instantiated from 2 `RGeo::CoordSys::Proj4` objects and stores the crs_to_crs.
- Create a singleton class `RGeo::CoordSys::CRSStore` that maps some combination of Proj4 objects to a `CRSToCRS` object.
When running transform_coords, check the `CRSStore `to see if the mapping exists, if not create it and store it, else get it.
- Change the underlying C function to accept the `crs_to_crs` instead of 2 projections and just transform the coordinates

Fix #19 