### PR TITLE
Fix `Psych.load` Issue

### DIFF
--- a/test/common/factory_tests.rb
+++ b/test/common/factory_tests.rb
@@ -64,7 +64,7 @@ module RGeo
 
         def test_psych_dump_load_factory
           data = Psych.dump(@factory)
-          factory2 = Psych.load(data)
+          factory2 = psych_load(data)
           assert_equal(@factory, factory2)
           assert_equal(srid, factory2.srid)
         end

--- a/test/common/line_string_tests.rb
+++ b/test/common/line_string_tests.rb
@@ -320,7 +320,7 @@ module RGeo
           point2 = @factory.point(0, 1)
           line1 = @factory.line_string([point1, point2])
           data = Psych.dump(line1)
-          line2 = Psych.load(data)
+          line2 = psych_load(data)
           assert_equal(line1, line2)
         end
       end

--- a/test/common/point_tests.rb
+++ b/test/common/point_tests.rb
@@ -341,21 +341,21 @@ module RGeo
         def test_psych_roundtrip
           point = @factory.point(11, 12)
           data = Psych.dump(point)
-          point2 = Psych.load(data)
+          point2 = psych_load(data)
           assert_equal(point, point2)
         end
 
         def test_psych_roundtrip_3d
           point = @zfactory.point(11, 12, 13)
           data = Psych.dump(point)
-          point2 = Psych.load(data)
+          point2 = psych_load(data)
           assert_equal(point, point2)
         end
 
         def test_psych_roundtrip_4d
           point = @zmfactory.point(11, 12, 13, 14)
           data = Psych.dump(point)
-          point2 = Psych.load(data)
+          point2 = psych_load(data)
           assert_equal(point, point2)
         end
       end

--- a/test/coord_sys/proj4_test.rb
+++ b/test/coord_sys/proj4_test.rb
@@ -126,7 +126,7 @@ class TestProj4 < Minitest::Test # :nodoc:
   def test_yaml_roundtrip
     obj1 = RGeo::CoordSys::Proj4.create("+proj=longlat +ellps=WGS84 +datum=WGS84 +no_defs +type=crs")
     dump = Psych.dump(obj1)
-    obj2 = Psych.load(dump)
+    obj2 = psych_load(dump)
     assert_equal(obj1, obj2)
   end
 

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -5,3 +5,13 @@ require "rgeo/proj4"
 require "common/factory_tests"
 require "psych"
 require "pry-byebug"
+
+# Only here for Psych 4.0.0 breaking change.
+# See https://github.com/ruby/psych/pull/487
+def psych_load(*args)
+  if Psych.respond_to?(:unsafe_load)
+    Psych.unsafe_load(*args)
+  else
+    Psych.load(*args)
+  end
+end


### PR DESCRIPTION
Copied solution from https://github.com/rgeo/rgeo/commit/ca1d7d03103ffaeed9bfe895e35eb7c721a2b96e.

Picks whether to use `Psych.load` or `Psych.unsafe_load` based on version.