### PR TITLE
feat: relax RGeo dependency

### DIFF
--- a/rgeo-proj4.gemspec
+++ b/rgeo-proj4.gemspec
@@ -15,7 +15,7 @@ Gem::Specification.new do |spec|
   spec.files         = Dir["lib/**/*.rb", "ext/**/*.{rb,c,h}", "LICENSE.txt"]
   spec.extensions    = ["ext/proj4_c_impl/extconf.rb"]
 
-  spec.add_dependency "rgeo", "~> 2.0"
+  spec.add_dependency "rgeo", ">= 2.0"
 
   spec.add_development_dependency "minitest", "~> 5.14"
   spec.add_development_dependency "rake", "~> 13.0"


### PR DESCRIPTION
RGeo will release the 3.0 version soon.
`rgeo` v3 works with the current version of `rgeo-proj` without any issues.