### PR TITLE
Add More Checks to Extconf

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -39,10 +39,10 @@ jobs:
         if: matrix.os == 'ubuntu'
         run: |
           sudo add-apt-repository ppa:ubuntugis/ubuntugis-unstable
-          sudo apt-get install curl libcurl4-openssl-dev libssl-dev libgeos-dev
+          sudo apt-get install curl libcurl4-openssl-dev libssl-dev libgeos-dev cmake
       - name: Install Packages (Mac)
         if: matrix.os == 'macos'
-        run: brew install geos make
+        run: brew install geos cmake
       - uses: actions/cache@v2
         id: proj-cache
         with:
@@ -53,14 +53,16 @@ jobs:
         run: |
           wget -c https://download.osgeo.org/proj/proj-${{ matrix.proj }}.tar.gz -O - | tar -xz
           cd proj-${{ matrix.proj }}
-          ./configure --enable-shared --enable-fast-install
-          make -j 8
-          cd ../
+          mkdir build
+          cd build
+          cmake ..
+          cmake --build .
+          cd ../../
       - name: Install Proj
         run: |
-          cd proj-${{ matrix.proj }}
-          sudo make install
-          cd ../
+          cd proj-${{ matrix.proj }}/build
+          sudo cmake --build . --target install
+          cd ../../
       - uses: ruby/setup-ruby@v1
         with:
           ruby-version: ${{ matrix.ruby }}

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -47,7 +47,7 @@ jobs:
         id: proj-cache
         with:
           path: ./proj-${{ matrix.proj }}
-          key: proj-${{ matrix.proj }}-os-${{ matrix.os }}
+          key: proj-${{ matrix.proj }}-os-${{ matrix.os }}-cmake-version
       - name: Download and Compile Proj
         if: steps.proj-cache.outputs.cache-hit != 'true'
         run: |

--- a/Gemfile
+++ b/Gemfile
@@ -5,4 +5,4 @@ gemspec
 gem "pry-byebug" unless ENV["CI"]
 
 # TODO: remove once we actually release version 3
-gem "rgeo", git: "https://github.com/rgeo/rgeo", branch: "v3-proj-rework"
+gem "rgeo", git: "https://github.com/rgeo/rgeo", branch: "main"

--- a/ext/proj4_c_impl/extconf.rb
+++ b/ext/proj4_c_impl/extconf.rb
@@ -57,9 +57,9 @@ else
       proj_create_crs_to_crs_from_pj
       proj_normalize_for_visualization
     ]
-    found_valid_proj_version = required_proj_funcs.map do |func|
+    found_valid_proj_version = required_proj_funcs.all? do |func|
       have_func(func, "proj.h")
-    end.all?(true)
+    end
   end
   have_func("rb_gc_mark_movable")
 

--- a/ext/proj4_c_impl/extconf.rb
+++ b/ext/proj4_c_impl/extconf.rb
@@ -12,7 +12,7 @@ else
 
   require "mkmf"
 
-  header_dirs_ =
+  header_dirs =
     [
       ::RbConfig::CONFIG["includedir"],
       "/usr/local/include",
@@ -26,7 +26,7 @@ else
       "/Library/Frameworks/PROJ.framework/unix/include",
       "/usr/include"
     ]
-  lib_dirs_ =
+  lib_dirs =
     [
       ::RbConfig::CONFIG["libdir"],
       "/usr/local/lib",
@@ -42,28 +42,65 @@ else
       "/usr/lib",
       "/usr/lib64"
     ]
-  header_dirs_.delete_if { |path_| !::File.directory?(path_) }
-  lib_dirs_.delete_if { |path_| !::File.directory?(path_) }
+  header_dirs.delete_if { |path| !::File.directory?(path) }
+  lib_dirs.delete_if { |path| !::File.directory?(path) }
 
-  found_proj_ = false
-  header_dirs_, lib_dirs_ = dir_config("proj", header_dirs_, lib_dirs_)
+  found_proj = false
+  found_valid_proj_version = false
+  header_dirs, lib_dirs = dir_config("proj", header_dirs, lib_dirs)
   if have_header("proj.h")
     $libs << " -lproj"
+    found_proj = true
 
-    if have_func("proj_create", "proj.h")
-      found_proj_ = true
-      have_func("proj_create_crs_to_crs_from_pj", "proj.h")
-      have_func("proj_normalize_for_visualization", "proj.h")
-    else
-      $libs.gsub!(" -lproj", "")
-    end
+    required_proj_funcs = %w[
+      proj_create
+      proj_create_crs_to_crs_from_pj
+      proj_normalize_for_visualization
+    ]
+    found_valid_proj_version = required_proj_funcs.map do |func|
+      have_func(func, "proj.h")
+    end.all?(true)
   end
   have_func("rb_gc_mark_movable")
 
-  unless found_proj_
-    puts "**** WARNING: Unable to find Proj headers or Proj version is too old."
-    puts "**** Compiling without Proj support."
-  end
-  create_makefile("rgeo/coord_sys/proj4_c_impl")
+  unless found_proj
 
+    install_text = case RUBY_PLATFORM
+                   when /linux/
+                     %(
+  Please install proj like so:
+    apt-get install libproj-dev proj-bin
+                     )
+                   when /darwin/
+                     %(
+  Please install proj like so:
+    brew install proj
+                     )
+                   else
+                     %(
+  Please install proj.
+                     )
+                   end
+    error_msg = %(
+**** WARNING: Unable to find Proj headers. Ensure that Proj is properly installed.
+
+#{install_text}
+
+or set the path manually using:
+ --with-proj-dir or with the --with-proj-include and --with-proj-lib options
+    )
+    warn error_msg
+    raise
+  end
+
+  unless found_valid_proj_version
+    error_msg = %(
+**** WARNING: The found Proj version is not new enough to be used for this version of rgeo-proj4.
+**** Proj 6.2+ is required.
+    )
+    warn error_msg
+    raise
+  end
+
+  create_makefile("rgeo/coord_sys/proj4_c_impl")
 end


### PR DESCRIPTION
Since this gem does not really have any functionality without Proj compiled, this PR adds stricter checks to ensure that all functions required for `RGeo::Proj4.supported?` are checked before compilation and the extconf will raise if they are not all met. Also adds more helpful error messages based on whether the cause of failure is proj not being found or an old version being found.

Since we are removing the dependency of the core gem on rgeo-proj4, the core gem won't need to call `supported?` anymore and this should be safe to do with RGeo 3+. Although I'm opening to allowing it to compile still and just leaving the warnings.

Related comment: https://github.com/rgeo/rgeo-proj4/issues/15#issuecomment-1269202794