### PR TITLE
fix(ext): segv on fork

### DIFF
--- a/History.md
+++ b/History.md
@@ -1,3 +1,8 @@
+### Ongoing
+
+**Bug Fixes**
+* Avoid a segfault when forking (`Process.fork`). #40
+
 ### 4.0.0 / 2023-01-25
 
 **Minor Changes**

--- a/test/non_regression_test.rb
+++ b/test/non_regression_test.rb
@@ -1,0 +1,23 @@
+# frozen_string_literal: true
+
+require_relative "test_helper"
+require "timeout"
+
+class NonRegressionTest < Minitest::Test
+  # When this test fail, you should end up with a segv or this test will
+  # hang forever. In both cases, you'll see that there is an issue. Note
+  # that it does not fail systematically, so running it ~10 times will
+  # help you be sure that you are not regressing on that topic again.
+  #
+  # See https://github.com/rgeo/rgeo-proj4/issues/39.
+  def test_forking_issue39
+    RGeo::CoordSys::Proj4.create("EPSG:4326")
+    pid = Process.fork {}
+    Process.wait pid
+  ensure
+    begin
+      Process.kill(9, pid)
+    rescue Errno::ESRCH # rubocop:disable Lint/SuppressedException
+    end
+  end
+end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -5,7 +5,7 @@ at_exit { GC.start } if ENV["LD_PRELOAD"]&.include? "valgrind"
 
 require "minitest/autorun"
 require "rgeo/proj4"
-require "common/factory_tests"
+require_relative "common/factory_tests"
 require "psych"
 
 # Only here for Psych 4.0.0 breaking change.


### PR DESCRIPTION
We would segv when using proj and then fork a process. This is fixed by using proj's thread-safe context.