### PR TITLE
Ruby 4.0 support

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -13,6 +13,7 @@ jobs:
       matrix:
         ruby:
           - head
+          - "4.0"
           - "3.1"
           - "3.0"
           - "2.7"
@@ -34,7 +35,7 @@ jobs:
     runs-on: ${{ matrix.os }}-latest
     name: Ruby ${{ matrix.ruby }}, Proj-${{ matrix.proj }} (${{ matrix.os }})
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v6
       - name: Install Packages (Linux)
         if: matrix.os == 'ubuntu'
         run: |
@@ -43,7 +44,7 @@ jobs:
       - name: Install Packages (Mac)
         if: matrix.os == 'macos'
         run: brew install geos cmake
-      - uses: actions/cache@v2
+      - uses: actions/cache@v5
         id: proj-cache
         with:
           path: ./proj-${{ matrix.proj }}
@@ -80,10 +81,10 @@ jobs:
   Memcheck:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v6
       - uses: ruby/setup-ruby@v1
         with:
-          ruby-version: "3.1"
+          ruby-version: "4.0"
           bundler-cache: true
       - name: Install dependencies
         run: |
@@ -94,10 +95,10 @@ jobs:
   RuboCop:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v6
       - uses: ruby/setup-ruby@v1
         with:
-          ruby-version: "3.1"
+          ruby-version: "4.0"
           bundler-cache: true
       - run: |
           bundle exec rubocop --color --parallel
@@ -107,7 +108,7 @@ jobs:
     #   outdated clang-format package.
     runs-on: ubuntu-22.04
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v6
       - name: Install clang-format
         run: sudo apt-get install -yqq clang-format
       - name: Show version

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -12,15 +12,9 @@ jobs:
       fail-fast: false
       matrix:
         ruby:
-          - head
           - "4.0"
-          - "3.4"
-          - "3.3"
-          - "3.2"
-          - "3.1"
         os:
           - ubuntu
-          - macos
         proj:
           - "9.7.1"
           - "9.6.2"
@@ -38,6 +32,25 @@ jobs:
           - "7.0.1"
           - "6.3.1"
           - "6.2.1"
+        include:
+          - os: ubuntu
+            ruby: head
+            proj: "9.7.1"
+          - os: ubuntu
+            ruby: "3.4"
+            proj: "9.7.1"
+          - os: ubuntu
+            ruby: "3.3"
+            proj: "9.7.1"
+          - os: ubuntu
+            ruby: "3.2"
+            proj: "9.7.1"
+          - os: ubuntu
+            ruby: "3.1"
+            proj: "9.7.1"
+          - os: macos
+            ruby: "4.0"
+            proj: "9.7.1"
     runs-on: ${{ matrix.os }}-latest
     name: Ruby ${{ matrix.ruby }}, Proj-${{ matrix.proj }} (${{ matrix.os }})
     steps:

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -14,14 +14,20 @@ jobs:
         ruby:
           - head
           - "4.0"
+          - "3.4"
+          - "3.3"
+          - "3.2"
           - "3.1"
-          - "3.0"
-          - "2.7"
-          - "2.6"
         os:
           - ubuntu
           - macos
         proj:
+          - "9.7.1"
+          - "9.6.2"
+          - "9.5.1"
+          - "9.4.1"
+          - "9.3.1"
+          - "9.2.1"
           - "9.1.0"
           - "9.0.1"
           - "8.2.1"
@@ -40,10 +46,15 @@ jobs:
         if: matrix.os == 'ubuntu'
         run: |
           sudo add-apt-repository ppa:ubuntugis/ubuntugis-unstable
-          sudo apt-get install curl libcurl4-openssl-dev libssl-dev libgeos-dev cmake
+          sudo apt-get install curl libcurl4-openssl-dev libssl-dev libgeos-dev cmake libtiff-dev
+          echo "CC=gcc-12" >> $GITHUB_ENV
+          echo "CXX=g++-12" >> $GITHUB_ENV
       - name: Install Packages (Mac)
         if: matrix.os == 'macos'
-        run: brew install geos cmake
+        run: |
+          brew install geos cmake
+
+          echo DYLD_LIBRARY_PATH=/usr/local/lib:$DYLD_LIBRARY_PATH >> $GITHUB_ENV
       - uses: actions/cache@v5
         id: proj-cache
         with:
@@ -56,13 +67,13 @@ jobs:
           cd proj-${{ matrix.proj }}
           mkdir build
           cd build
-          cmake ..
+          cmake -DBUILD_TESTING=OFF -DPROJ_TESTS=OFF -DCMAKE_POLICY_VERSION_MINIMUM=3.5 ..
           cmake --build .
           cd ../../
       - name: Install Proj
         run: |
           cd proj-${{ matrix.proj }}/build
-          cmake ..
+          cmake -DBUILD_TESTING=OFF -DPROJ_TESTS=OFF -DCMAKE_POLICY_VERSION_MINIMUM=3.5 ..
           cmake --build .
           sudo cmake --build . --target install
           cd ../../

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -78,7 +78,7 @@ jobs:
           cd proj-${{ matrix.proj }}
           mkdir build
           cd build
-          cmake -DBUILD_TESTING=OFF -DPROJ_TESTS=OFF -DCMAKE_POLICY_VERSION_MINIMUM=3.5 ..
+          cmake -DBUILD_TESTING=OFF -DCMAKE_POLICY_VERSION_MINIMUM=3.5 ..
           cmake --build .
           cd ../../
       - name: Install Proj

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -30,8 +30,6 @@ jobs:
           - "7.2.1"
           - "7.1.1"
           - "7.0.1"
-          - "6.3.1"
-          - "6.2.1"
         include:
           - os: ubuntu
             ruby: head
@@ -59,7 +57,7 @@ jobs:
         if: matrix.os == 'ubuntu'
         run: |
           sudo add-apt-repository ppa:ubuntugis/ubuntugis-unstable
-          sudo apt-get install curl libcurl4-openssl-dev libssl-dev libgeos-dev cmake libtiff-dev
+          sudo apt-get install -yqq curl libcurl4-openssl-dev libssl-dev libgeos-dev cmake libtiff-dev
           echo "CC=gcc-12" >> $GITHUB_ENV
           echo "CXX=g++-12" >> $GITHUB_ENV
       - name: Install Packages (Mac)
@@ -86,7 +84,7 @@ jobs:
       - name: Install Proj
         run: |
           cd proj-${{ matrix.proj }}/build
-          cmake -DBUILD_TESTING=OFF -DPROJ_TESTS=OFF -DCMAKE_POLICY_VERSION_MINIMUM=3.5 ..
+          cmake -DBUILD_TESTING=OFF -DCMAKE_POLICY_VERSION_MINIMUM=3.5 ..
           cmake --build .
           sudo cmake --build . --target install
           cd ../../

--- a/History.md
+++ b/History.md
@@ -4,10 +4,7 @@
 * Minimum required Ruby version is now 3.1. #44
 
 *** Minor Changes
-* Update RGeo to 3.1.0. #44
-* Add Ruby 4.0 to CI. #44
-* Remove Proj < 7 from CI. #44
-* Only test MacOS against latest Proj and stable Ruby. #44
+* Add support for ruby 4.0 #44
 
 **Bug Fixes**
 * Avoid a segfault when forking (`Process.fork`). #40

--- a/History.md
+++ b/History.md
@@ -1,5 +1,14 @@
 ### Ongoing
 
+*** Breaking Changes**
+* Minimum required Ruby version is now 3.1. #44
+
+*** Minor Changes
+* Update RGeo to 3.1.0. #44
+* Add Ruby 4.0 to CI. #44
+* Remove Proj < 7 from CI. #44
+* Only test MacOS against latest Proj and stable Ruby. #44
+
 **Bug Fixes**
 * Avoid a segfault when forking (`Process.fork`). #40
 

--- a/rgeo-proj4.gemspec
+++ b/rgeo-proj4.gemspec
@@ -10,7 +10,7 @@ Gem::Specification.new do |spec|
   spec.description   = "Proj4 extension for rgeo."
   spec.homepage      = "https://github.com/rgeo/rgeo-proj4"
   spec.license       = "MIT"
-  spec.required_ruby_version = ">= 2.6.0"
+  spec.required_ruby_version = ">= 3.1.4"
 
   spec.files         = Dir["lib/**/*.rb", "ext/**/*.{rb,c,h}", "LICENSE.txt"]
   spec.extensions    = ["ext/proj4_c_impl/extconf.rb"]
@@ -21,6 +21,6 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "minitest", "~> 5.14"
   spec.add_development_dependency "rake", "~> 13.0"
   spec.add_development_dependency "rake-compiler", "~> 1.0"
-  spec.add_development_dependency "rubocop", "~> 1.8.1"
+  spec.add_development_dependency "rubocop", "~> 1.82.1"
   spec.add_development_dependency "ruby_memcheck", "~> 1.0"
 end

--- a/rgeo-proj4.gemspec
+++ b/rgeo-proj4.gemspec
@@ -15,7 +15,7 @@ Gem::Specification.new do |spec|
   spec.files         = Dir["lib/**/*.rb", "ext/**/*.{rb,c,h}", "LICENSE.txt"]
   spec.extensions    = ["ext/proj4_c_impl/extconf.rb"]
 
-  spec.add_dependency "rgeo", "~> 3.0.0"
+  spec.add_dependency "rgeo", "~> 3.1.0"
 
   spec.add_development_dependency "ffi-geos", "~> 2.2"
   spec.add_development_dependency "minitest", "~> 5.14"


### PR DESCRIPTION
- update github actions
- update rgeo to 3.1.0
- increase minimum supported ruby version to 3.1.4 (matches rgeo)
- Add ruby 4.0, 3.4, 3.3, and 3.2 to build matrix
- Add new PROJ versions to build matrix
- set `DYLD_LIBRARY_PATH` to avoid `Library not loaded: @rpath/libproj.25.dylib` when bundling on macos runner (Is this something that should somehow be fixed in extconf.rb?
- set `-DBUILD_TESTING=OFF -DPROJ_TESTS=OFF` to build PROJ against Cmake 4.x (macos builder comes with 4.x)
- Use gcc 12 to avoid `error: ‘int64_t’ in namespace ‘std’ does not name a type` [error](https://github.com/kurtronshausen/rgeo-proj4/actions/runs/21299397985/job/61313077152#step:6:326)